### PR TITLE
Adds support for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A library cookbook that provides LWRPs for extracting archive files
 ## Supported Platforms
 
 * Ubuntu
+* Arch Linux
 
 ## Usage
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,7 @@ long_description "A library cookbook for extracting archive files"
 version          "0.4.1"
 
 supports "ubuntu"
+supports "arch"
 
 depends "build-essential", "~> 2.0"
 depends "apt", "~> 2.5"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ when platform_family?("rhel")
   package "libarchive-devel" do
     action :nothing
   end.run_action(:install)
-when platform_family("arch")
+when platform_family?("arch")
   package "libarchive" do
     action :nothing
   end.run_action(:install)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,10 @@ when platform_family?("rhel")
   package "libarchive-devel" do
     action :nothing
   end.run_action(:install)
+when platform_family("arch")
+  package "libarchive" do
+    action :nothing
+  end.run_action(:install)
 else
   Chef::Application.fatal! "[libarchive] unsupported platform family: #{node[:platform_family]}"
 end


### PR DESCRIPTION
I have added support for the [Arch Linux](http://archlinux.org/) (`arch`) platform, which has a [libarchive](https://www.archlinux.org/packages/?q=libarchive) package available in the official repositories.