### PR TITLE
Installing build-essential at build time causes errors

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,4 +39,5 @@ end
 
 chef_gem "libarchive-ruby" do
   version "0.0.3"
+  compile_time true if respond_to?(:compile_time)
 end


### PR DESCRIPTION
I'm running a recipe that includes libarchive but it is erroring out ever time I first run the recipe with a clean box. I've tracked it down the to fact that autoconf isn't know to apt-cache, which means that apt-get update needs to be run before I include your recipe. 

I tried to include the "apt" recipe (which does an apt-get update) before i include libarchive but it still doesn't work. Looking at your code i've noticed that you're trying to install build essential at compile time, why? https://github.com/reset/libarchive-cookbook/blob/master/recipes/default.rb#L8

if this is pushed back into runtime then the apt recipe will have a chance to do an apt-get update before package build-essential needs to install anything. 