### PR TITLE
Add chef11 compatability

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,5 +37,5 @@ end
 
 chef_gem "libarchive-ruby" do
   version "0.0.3"
-  compile_time false
+  compile_time false if respond_to?(:compile_time)
 end


### PR DESCRIPTION
Make this only set compile_time attribute when it is available on the chef_gem resource.