### PR TITLE
added libarchive-devel package for ffi support on RHEL platform families

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,8 @@
 #
 if platform_family?('debian')
   default['libarchive']['package_name'] = 'libarchive-dev'
+elsif platform_family?('rhel')
+  default['libarchive']['package_name'] = 'libarchive-devel'
 else
   default['libarchive']['package_name'] = 'libarchive'
 end


### PR DESCRIPTION
Like debian, rhel based platforms also depend on the libarchive-dev(el) package for ffi interaction.
Tested on local VMs (CentOS, Ubuntu) and amazon linux deployments.