### PR TITLE
Adds matcher definition for ChefSpec testing.

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,4 +1,5 @@
 if defined?(ChefSpec)
+  ChefSpec.define_matcher :libarchive_file
   def extract_libarchive_file(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:libarchive_file, :extract, resource_name)
   end


### PR DESCRIPTION
This adds a [custom matcher definition](https://github.com/sethvargo/chefspec#writing-custom-matchers) so that we can easily test notifications.