### PR TITLE
Call archive.close after extract

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -46,6 +46,8 @@ module LibArchiveCookbook
 
             archive.extract(e, flags.to_i)
           end
+          
+          archive.close()
         end
 
         modified


### PR DESCRIPTION
I was having an issue where all directory permissions in the archive I was extracting were ending up 0700. 

For instance, this block is extracting a jruby binary into /opt. The tarball has its contents inside a directory, so the extract ends up creating /opt/jruby-9.0.4.0/.

```
    libarchive_file archive.path do
      extract_to node.scpr_apps.jruby_install_path
      extract_options [:permissions,:no_overwrite]
    end
```

Run against current HEAD for libarchive-cookbook, I end up with: 

```
vagrant@jruby-ubuntu-1204:~/jruby-9.0.4.0$ ls -l /opt/
total 12
drwxr-xr-x 4 root root 4096 Dec 10 14:08 chef
drwx------ 6 root root 4096 Dec 10 15:46 jruby-9.0.4.0
drwxr-xr-x 9 root root 4096 May 11  2013 VBoxGuestAdditions-4.2.12
```

Same for all directories deeper in the tarball.

Adding `archive.close()` in extract causes the libarchive `archive_read_free` function to be called, which does a fixup pass to set directory permissions to what they are in the archive. With it added, my extract looks correct.

cc: @johnbellone 